### PR TITLE
Remove CNAME from docs site

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-carpenter.coffee


### PR DESCRIPTION
Removing CNAME for this demo site, as it redirects to another domain that appears to no longer be valid

https://rapid7.github.io/marionette.carpenter

Site:

![image](https://github.com/rapid7/marionette.carpenter/assets/60357436/384a09cc-b87c-4d04-9f8b-d9a1fa0731ee)
